### PR TITLE
Fix improper href link

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <p align="center">
           <samp>
             <a href="https://github.com/Katzadoo">me</a> .
-            <a href="//https://dev.to/katzdev">dev.to</a> .
+            <a href="https://dev.to/katzdev">dev.to</a> .
             <a href="https://github.com/Katzadoo?tab=repositories">projects</a> .
             <a href="https://open.spotify.com/user/dalitsoomg">spotify</a> .
             <a href="https://twitter.com/Katzadoo">tweets</a> 


### PR DESCRIPTION
Hi,

Just saw the href link to dev.to was mentioned incorrectly in index page. PR to fix the issue. If you think this is not proper, you can decline it. It was just setting me off.